### PR TITLE
fix: resolving the dependency tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"react-native-jdenticon"
 	],
 	"peerDependencies": {
-		"react-native-svg": "^11.0.1"
+		"react-native-svg": ">=11.0.1"
 	},
 	"dependencies": {
 		"jdenticon": "^2.2.0"


### PR DESCRIPTION
"react-native-svg": ">=11.0.1" to support newer versions of the dependency.